### PR TITLE
Use computed property after doing basic sanitization

### DIFF
--- a/tensorboard/components/tf_tensorboard/test/tensorboardTests.ts
+++ b/tensorboard/components/tf_tensorboard/test/tensorboardTests.ts
@@ -18,6 +18,7 @@ namespace tf_tensorboard {
   declare function fixture(id: string): void;
   declare function flush(callback: Function): void;
   declare const Polymer: any;
+  declare const TEST_ONLY: any;
 
   function checkSlottedUnderAncestor(element: Element, ancestor: Element) {
     expect(!!element.assignedSlot).to.be.true;
@@ -32,10 +33,11 @@ namespace tf_tensorboard {
       let tensorboard: any;
 
       describe('base tests', () => {
-        beforeEach(function() {
+        beforeEach((done) => {
           tensorboard = fixture('tensorboardFixture');
           tensorboard.demoDir = 'data';
           tensorboard.autoReloadEnabled = false;
+          flush(done);
         });
 
         it('renders injected content', function() {
@@ -50,25 +52,15 @@ namespace tf_tensorboard {
           checkSlottedUnderAncestor(headerItem2, header);
         });
 
-        it('uses "TensorBoard-X" for title text by default', (done) => {
-          flush(() => {
-            const title = tensorboard.shadowRoot.querySelector(
-              '.toolbar-title'
-            );
-            chai.assert.equal(title.textContent, 'TensorBoard-X');
-            done();
-          });
+        it('uses "TensorBoard-X" for title text by default', () => {
+          const title = tensorboard.shadowRoot.querySelector('.toolbar-title');
+          chai.assert.equal(title.textContent, 'TensorBoard-X');
         });
 
-        it('uses div for title element by default ', (done) => {
-          flush(() => {
-            const title = tensorboard.shadowRoot.querySelector(
-              '.toolbar-title'
-            );
-            chai.assert.equal(title.nodeName, 'DIV');
-            chai.assert.isUndefined(title.href);
-            done();
-          });
+        it('uses div for title element by default ', () => {
+          const title = tensorboard.shadowRoot.querySelector('.toolbar-title');
+          chai.assert.equal(title.nodeName, 'DIV');
+          chai.assert.isUndefined(title.href);
         });
 
         // TODO(psybuzz): Restore/remove these old tests, which fail due to broken
@@ -136,41 +128,57 @@ namespace tf_tensorboard {
         });
       });
 
-      describe('customization tests', () => {
-        beforeEach(function() {
-          tensorboard = fixture('customizedTensorboardFixture');
+      describe('custom path', () => {
+        let sandbox: any;
+
+        beforeEach((done) => {
+          sandbox = sinon.sandbox.create();
+          sandbox.stub(TEST_ONLY.lib, 'getLocation').returns({
+            href: 'https://tensorboard.is/cool',
+            origin: 'https://tensorboard.is',
+          });
+
+          tensorboard = fixture('tensorboardFixture');
           tensorboard.demoDir = 'data';
+          tensorboard.brand = 'Custom Brand';
           tensorboard.autoReloadEnabled = false;
+          tensorboard.homePath = '/awesome';
+
+          // Branding and other components use `dom-if` which updates the dom in an
+          // animation frame. Flush and remove the asynchronicity.
+          flush(done);
         });
 
-        it('uses customized brand for title', (done) => {
-          flush(() => {
-            const title = tensorboard.shadowRoot.querySelector(
-              '.toolbar-title'
-            );
-            chai.assert.equal(title.textContent, 'Custom Brand');
-            done();
-          });
+        afterEach(() => {
+          sandbox.restore();
         });
 
-        it('uses customized href for title element ', (done) => {
-          flush(() => {
-            const title = tensorboard.shadowRoot.querySelector(
-              '.toolbar-title'
-            );
-            chai.assert.equal(title.nodeName, 'A');
-            chai.assert.equal(title.href, 'http://custom.home/');
-            done();
-          });
+        it('uses customized brand for title', () => {
+          const title = tensorboard.shadowRoot.querySelector('.toolbar-title');
+          chai.assert.equal(title.textContent, 'Custom Brand');
         });
-      });
 
-      describe('bad homeHref', () => {
-        it('does not render the logo as hyperlink', () => {
-          const tensorboard = fixture('customizedTensorboardFixture') as any;
-          // It is impossible to set false as prop in Polymer.
-          tensorboard.autoReloadEnabled = false;
+        it('uses customized path for title element ', () => {
+          const title = tensorboard.shadowRoot.querySelector('.toolbar-title');
+          chai.assert.equal(title.nodeName, 'A');
+          chai.assert.equal(title.href, 'https://tensorboard.is/awesome');
+        });
 
+        it('does not render the logo as hyperlink for bad protocol', () => {
+          tensorboard.homePath = 'javascript:alert("PWNED!")';
+          chai.assert.isNull(
+            tensorboard.shadowRoot.querySelector('.toolbar-content a')
+          );
+
+          tensorboard.homePath =
+            'data:text/html,<img src="HEHE" onerror="alert(\'PWNED!\')" />';
+          chai.assert.isNull(
+            tensorboard.shadowRoot.querySelector('.toolbar-content a')
+          );
+        });
+
+        it('does not render the logo as hyperlink for bad wrong protocols', () => {
+          tensorboard.homePath = 'javascript:alert("PWNED!")';
           chai.assert.isNull(
             tensorboard.shadowRoot.querySelector('.toolbar-content a')
           );

--- a/tensorboard/components/tf_tensorboard/test/tensorboardTests.ts
+++ b/tensorboard/components/tf_tensorboard/test/tensorboardTests.ts
@@ -164,6 +164,18 @@ namespace tf_tensorboard {
           });
         });
       });
+
+      describe('bad homeHref', () => {
+        it('does not render the logo as hyperlink', () => {
+          const tensorboard = fixture('customizedTensorboardFixture') as any;
+          // It is impossible to set false as prop in Polymer.
+          tensorboard.autoReloadEnabled = false;
+
+          chai.assert.isNull(
+            tensorboard.shadowRoot.querySelector('.toolbar-content a')
+          );
+        });
+      });
     });
   });
 } // namespace tf_tensorboard

--- a/tensorboard/components/tf_tensorboard/test/tensorboardTests.ts
+++ b/tensorboard/components/tf_tensorboard/test/tensorboardTests.ts
@@ -164,24 +164,30 @@ namespace tf_tensorboard {
           chai.assert.equal(title.href, 'https://tensorboard.is/awesome');
         });
 
-        it('does not render the logo as hyperlink for bad protocol', () => {
-          tensorboard.homePath = 'javascript:alert("PWNED!")';
-          chai.assert.isNull(
-            tensorboard.shadowRoot.querySelector('.toolbar-content a')
-          );
+        it('throws when homePath is one of bad wrong protocols', () => {
+          const expectedError1 =
+            "Expect 'homePath' to be of http: or https:. " +
+            'javascript:alert("PWNED!")';
+          chai.assert.throws(() => {
+            tensorboard.homePath = 'javascript:alert("PWNED!")';
+          }, expectedError1);
 
-          tensorboard.homePath =
+          const expectedError2 =
+            "Expect 'homePath' to be of http: or https:. " +
             'data:text/html,<img src="HEHE" onerror="alert(\'PWNED!\')" />';
-          chai.assert.isNull(
-            tensorboard.shadowRoot.querySelector('.toolbar-content a')
-          );
+          chai.assert.throws(() => {
+            tensorboard.homePath =
+              'data:text/html,<img src="HEHE" onerror="alert(\'PWNED!\')" />';
+          }, expectedError2);
         });
 
-        it('does not render the logo as hyperlink for bad wrong protocols', () => {
-          tensorboard.homePath = 'javascript:alert("PWNED!")';
-          chai.assert.isNull(
-            tensorboard.shadowRoot.querySelector('.toolbar-content a')
-          );
+        it('throws when homePath is not a path', () => {
+          const expectedError1 =
+            "Expect 'homePath' be a path or have the same origin. " +
+            'https://tensorboard.was/good vs. https://tensorboard.is';
+          chai.assert.throws(() => {
+            tensorboard.homePath = 'https://tensorboard.was/good';
+          }, expectedError1);
         });
       });
     });

--- a/tensorboard/components/tf_tensorboard/test/tests.html
+++ b/tensorboard/components/tf_tensorboard/test/tests.html
@@ -51,6 +51,13 @@ limitations under the License.
         <tf-tensorboard brand="Custom Brand" home-href="http://custom.home" />
       </template>
     </test-fixture>
+
+    <test-fixture id="badHomeHrefFixture">
+      <template>
+        <tf-tensorboard brand="Custom Brand" demo-dir=="data"
+        home-href="javascript:alert('gotcha!')" />
+      </template>
+    </test-fixture>
     <script src="tensorboardTests.js"></script>
     <script src="autoReloadTests.js"></script>
   </body>

--- a/tensorboard/components/tf_tensorboard/test/tests.html
+++ b/tensorboard/components/tf_tensorboard/test/tests.html
@@ -46,18 +46,6 @@ limitations under the License.
       </template>
     </test-fixture>
 
-    <test-fixture id="customizedTensorboardFixture">
-      <template>
-        <tf-tensorboard brand="Custom Brand" home-href="http://custom.home" />
-      </template>
-    </test-fixture>
-
-    <test-fixture id="badHomeHrefFixture">
-      <template>
-        <tf-tensorboard brand="Custom Brand" demo-dir=="data"
-        home-href="javascript:alert('gotcha!')" />
-      </template>
-    </test-fixture>
     <script src="tensorboardTests.js"></script>
     <script src="autoReloadTests.js"></script>
   </body>

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -493,7 +493,15 @@ limitations under the License.
 
     const DATA_SELECTION_CHANGE_DEBOUNCE_MS = 200;
 
+    /** @type {Object} */
+    const LocationType = {};
+    /** @type {string} */
+    LocationType.href = '';
+    /** @type {string} */
+    LocationType.origin = '';
+
     const lib = {
+      /** @return {LocationType} */
       getLocation() {
         return window.location;
       },
@@ -529,7 +537,7 @@ limitations under the License.
 
         _homePath: {
           type: String,
-          computed: '_sanitizehomePath(homePath)',
+          computed: '_sanitizeHomePath(homePath)',
         },
 
         /**
@@ -699,7 +707,7 @@ limitations under the License.
           '_activeDashboards, _selectedDashboard)',
       ],
 
-      _sanitizehomePath(homePath) {
+      _sanitizeHomePath(homePath) {
         if (!homePath) {
           return '';
         }
@@ -711,6 +719,18 @@ limitations under the License.
         // with Polymer data binding.
         const isHttp = url.protocol === 'http:' || url.protocol === 'https:';
         const sameOrigin = url.origin === location.origin;
+
+        if (!isHttp) {
+          throw new RangeError(
+            `Expect 'homePath' to be of http: or https:. ${homePath}`
+          );
+        }
+
+        if (!sameOrigin) {
+          throw new RangeError(
+            `Expect 'homePath' be a path or have the same origin. ${homePath} vs. ${location.origin}`
+          );
+        }
 
         return isHttp && sameOrigin ? url.toString() : '';
       },

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -61,11 +61,16 @@ limitations under the License.
     <paper-header-panel>
       <paper-toolbar id="toolbar" slot="header" class="header">
         <div id="toolbar-content" slot="top">
-          <template is="dom-if" if="[[!homeHref]]">
+          <template is="dom-if" if="[[!_homeHref]]">
             <div class="toolbar-title">[[brand]]</div>
           </template>
-          <template is="dom-if" if="[[homeHref]]">
-            <a href="[[homeHref]]" class="toolbar-title">[[brand]]</a>
+          <template is="dom-if" if="[[_homeHref]]">
+            <a
+              href="[[_homeHref]]"
+              rel="noopener noreferrer"
+              class="toolbar-title"
+              >[[brand]]</a
+            >
           </template>
           <template is="dom-if" if="[[_activeDashboardsNotLoaded]]">
             <span class="toolbar-message">
@@ -509,7 +514,12 @@ limitations under the License.
          */
         homeHref: {
           type: String,
-          value: null,
+          value: '',
+        },
+
+        _homeHref: {
+          type: String,
+          computed: '_sanitizeHomeHref(homeHref)',
         },
 
         /**
@@ -678,6 +688,20 @@ limitations under the License.
           '_dashboardRegistry, _dashboardContainersStamped, ' +
           '_activeDashboards, _selectedDashboard)',
       ],
+
+      _sanitizeHomeHref(homeHref) {
+        if (!homeHref) {
+          return '';
+        }
+
+        const url = new URL(homeHref);
+
+        // Do not allow javascript:, data:, or unknown protocols to render
+        // with Polymer data binding.
+        const isHttp = url.protocol === 'http:' || url.protocol === 'https:';
+
+        return isHttp ? homeHref : '';
+      },
 
       _activeDashboardsUpdated(activeDashboards, selectedDashboard) {},
 

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -61,12 +61,12 @@ limitations under the License.
     <paper-header-panel>
       <paper-toolbar id="toolbar" slot="header" class="header">
         <div id="toolbar-content" slot="top">
-          <template is="dom-if" if="[[!_homeHref]]">
+          <template is="dom-if" if="[[!_homePath]]">
             <div class="toolbar-title">[[brand]]</div>
           </template>
-          <template is="dom-if" if="[[_homeHref]]">
+          <template is="dom-if" if="[[_homePath]]">
             <a
-              href="[[_homeHref]]"
+              href="[[_homePath]]"
               rel="noopener noreferrer"
               class="toolbar-title"
               >[[brand]]</a
@@ -493,6 +493,16 @@ limitations under the License.
 
     const DATA_SELECTION_CHANGE_DEBOUNCE_MS = 200;
 
+    const lib = {
+      getLocation() {
+        return window.location;
+      },
+    };
+
+    const TEST_ONLY = {
+      lib,
+    };
+
     Polymer({
       is: 'tf-tensorboard',
       behaviors: [tf_tensorboard.AutoReloadBehavior],
@@ -512,14 +522,14 @@ limitations under the License.
          * URL for navigation when clicking on the Title in the top left corner.
          * If unspecified then the Title will not be a clickable target.
          */
-        homeHref: {
+        homePath: {
           type: String,
           value: '',
         },
 
-        _homeHref: {
+        _homePath: {
           type: String,
-          computed: '_sanitizeHomeHref(homeHref)',
+          computed: '_sanitizehomePath(homePath)',
         },
 
         /**
@@ -689,18 +699,20 @@ limitations under the License.
           '_activeDashboards, _selectedDashboard)',
       ],
 
-      _sanitizeHomeHref(homeHref) {
-        if (!homeHref) {
+      _sanitizehomePath(homePath) {
+        if (!homePath) {
           return '';
         }
 
-        const url = new URL(homeHref);
+        const location = lib.getLocation();
+        const url = new URL(homePath, location.href);
 
         // Do not allow javascript:, data:, or unknown protocols to render
         // with Polymer data binding.
         const isHttp = url.protocol === 'http:' || url.protocol === 'https:';
+        const sameOrigin = url.origin === location.origin;
 
-        return isHttp ? homeHref : '';
+        return isHttp && sameOrigin ? url.toString() : '';
       },
 
       _activeDashboardsUpdated(activeDashboards, selectedDashboard) {},


### PR DESCRIPTION
Please review each commits separately. You may want to take only one of them.

Commit 1: we sanitize and disallow any hrefs that have illegal protocols (including //example.com).
Commit 2: since there are almost no case where we want TensorBoard to go to another domain (e.g., example.com), we changed the input to tf-tensorboard to take path instead of full href.